### PR TITLE
Fix maturin version used to build Python bindings

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-md-ulb-pwrap"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Python bindings for Rust crate md-ulb-pwrap."
 readme = "README.md"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin"]
 build-backend = "maturin"
 
 [project]
@@ -9,4 +9,11 @@ classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-ulb-pwrap"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Markdown paragraph wrapper using Unicode Line Breaking Algorithm."
 license = "BSD-3-Clause"


### PR DESCRIPTION
The new v0.1.1 has been built with maturin v0.14.4, when the previous was built with v1.2.0. This is probably due to https://github.com/PyO3/maturin-action/pull/46

Presumably fixes #7